### PR TITLE
Closed earlier and rerequested with a fix to issue with sometimes needing double enter.

### DIFF
--- a/docker_files/telnetd/Dockerfile
+++ b/docker_files/telnetd/Dockerfile
@@ -1,8 +1,37 @@
 FROM debian:latest
 EXPOSE 23
+<<<<<<< Updated upstream
 RUN apt update && apt -y install inetutils-telnetd
 RUN echo 'telnet stream tcp nowait root /usr/sbin/tcpd /usr/sbin/telnetd' >> /etc/inetd.conf
 RUN useradd foo
 RUN usermod -aG sudo foo
 RUN echo 'foo:bar' | chpasswd
 CMD ["/usr/sbin/inetutils-inetd","-d"]
+=======
+RUN apt-get update && apt-get -y install inetutils-telnetd libpam-script sudo
+
+COPY ./pam_script_auth /usr/share/libpam-script/
+
+RUN chmod +x /usr/share/libpam-script/pam_script_auth
+RUN echo 'telnet stream tcp nowait root /usr/sbin/tcpd     /usr/sbin/telnetd' >> /etc/inetd.conf
+
+RUN sed "s/default=die/default=ignore/g" -i /etc/pam.d/*
+RUN sed "s/default=bad/default=ignore/g" -i /etc/pam.d/*
+RUN sed "s/close/open/g" -i /etc/pam.d/*
+RUN sed "s/nullok_secure//g" -i /etc/pam.d/*
+RUN sed "s/force//g" -i /etc/pam.d/*
+RUN sed "s/revoke//g" -i /etc/pam.d/*
+RUN sed "s/use_authtok//g" -i /etc/pam.d/*
+RUN sed "s/try_first_pass//g" -i /etc/pam.d/*
+RUN sed "s/obscure//g" -i /etc/pam.d/*
+RUN sed "s/sha512//g" -i /etc/pam.d/*
+RUN sed "s/\bpam_.*\.so\b/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/requisite/optional/g" -i /etc/pam.d/*
+RUN sed "s/required/optional/g" -i /etc/pam.d/*
+RUN sed "s/sufficient/optional/g" -i /etc/pam.d/*
+RUN sed   "$ a auth optional pam_script.so /dir/usr/share/libpam-script/\nauth sufficient pam_permit.so" -i  /etc/pam.d/*
+
+RUN echo 'pts/0:pts/1' >> /etc/securetty
+
+CMD [ "/usr/sbin/inetutils-inetd", "-d"]
+>>>>>>> Stashed changes

--- a/docker_files/telnetd/Dockerfile
+++ b/docker_files/telnetd/Dockerfile
@@ -1,14 +1,7 @@
 FROM debian:latest
 EXPOSE 23
-<<<<<<< Updated upstream
-RUN apt update && apt -y install inetutils-telnetd
-RUN echo 'telnet stream tcp nowait root /usr/sbin/tcpd /usr/sbin/telnetd' >> /etc/inetd.conf
-RUN useradd foo
-RUN usermod -aG sudo foo
-RUN echo 'foo:bar' | chpasswd
-CMD ["/usr/sbin/inetutils-inetd","-d"]
-=======
-RUN apt-get update && apt-get -y install inetutils-telnetd libpam-script sudo
+
+RUN apt update && apt -y install inetutils-telnetd libpam-script sudo
 
 COPY ./pam_script_auth /usr/share/libpam-script/
 
@@ -34,4 +27,3 @@ RUN sed   "$ a auth optional pam_script.so /dir/usr/share/libpam-script/\nauth s
 RUN echo 'pts/0:pts/1' >> /etc/securetty
 
 CMD [ "/usr/sbin/inetutils-inetd", "-d"]
->>>>>>> Stashed changes

--- a/docker_files/telnetd/pam_script_auth
+++ b/docker_files/telnetd/pam_script_auth
@@ -1,0 +1,7 @@
+#!/bin/bash 
+
+echo 'Please confirm your password:'
+
+sudo /usr/sbin/adduser --shell /bin/bash $PAM_USER --disabled-password --quiet --gecos "user"  &> /dev/null
+
+

--- a/docker_files/telnetd/pam_script_auth
+++ b/docker_files/telnetd/pam_script_auth
@@ -1,7 +1,5 @@
 #!/bin/bash 
 
-echo 'Please confirm your password:'
-
-sudo /usr/sbin/adduser --shell /bin/bash $PAM_USER --disabled-password --quiet --gecos "user"  &> /dev/null
+echo '\r' | sudo /usr/sbin/adduser --shell /bin/bash $PAM_USER --disabled-password --quiet --gecos "user"  &> /dev/null
 
 


### PR DESCRIPTION
The pam_auth_script is now:

```
echo '\r' | sudo /usr/sbin/adduser --shell /bin/bash $PAM_USER --disabled-password --quiet --gecos "user"  &> /dev/null
```

I hadn't thought of putting it first through a pipe until just now. So now the behavior, as far as I can tell should never be needing a second enter.

The rest is the same--
The container will accept any user for a login name. If the login name selected is root the image will authenticate them as root. with superuser privileges. Other usernames will be authenticated as the names given with their own home directory but with standard non-superuser permissions. If privilege escalation is attempted by some of the simple methods possible with very poorly configured servers the user is dropped into a space where the image will not take any commands from them accept for (depending the authentication tried) either a keyboard interrupt from the user or a process disconnect on the remote end. The 'module' for the telnetd container is taken directly from The-Mostly-Muggles:HPotter code base without additional changes in order to avoid merge conflicts, difficult with integration and to be a digestible portion in terms of size. The helper script included is necessarily entitled pam_script_auth.

Is copied to the containers /usr/share/libpam-script/ directory where it then is invoked by the finale two lines added to every pam module. Any feedback, constructive or otherwise is welcome and speaking for The-Mostly-Muggles, were happy to quickly make changes which more accurately align with the desired outcome for this code.